### PR TITLE
Change dataAdapter to data-adapter

### DIFF
--- a/packages/fireplace/lib/initializers.js
+++ b/packages/fireplace/lib/initializers.js
@@ -29,10 +29,10 @@ Ember.onLoad('Ember.Application', function(Application) {
   });
 
   Application.initializer({
-    name: 'dataAdapter',
+    name: 'data-adapter',
 
     initialize: function(container, application) {
-      application.register('dataAdapter:main', FP.DebugAdapter);
+      application.register('data-adapter:main', FP.DebugAdapter);
     }
   });
 
@@ -51,7 +51,7 @@ Ember.onLoad('Ember.Application', function(Application) {
     initialize: function(container, application) {
       application.inject('controller',  'store', 'store:main');
       application.inject('route',       'store', 'store:main');
-      application.inject('dataAdapter', 'store', 'store:main');
+      application.inject('data-adapter', 'store', 'store:main');
       application.inject('collection',  'store', 'store:main');
       application.inject('component',   'store', 'store:main');
     }


### PR DESCRIPTION
I noticed that ember-inspector functionality wasn't working. Then I saw this pull request over at ember-model that fixed their similar problem. Sure enough, it was affecting fireplace as well.
